### PR TITLE
chore: update release workflow to trigger on 'main' branch instead of 'master'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request updates the GitHub Actions release workflow to trigger on pushes to the `main` branch instead of `master`.

- Changed the release workflow trigger branch from `master` to `main` in `.github/workflows/release.yml`