### PR TITLE
chore: remove NPM_CONFIG_PROVENANCE from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,5 +53,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
         run: npm run release -- --ci


### PR DESCRIPTION
This pull request makes a minor change to the release workflow configuration by removing the `NPM_CONFIG_PROVENANCE` environment variable. This simplifies the release process and may reflect a change in how provenance is handled during npm releases.