### PR TITLE
chore: update package dependencies in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.9.0",
-        "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.2"
+        "axios": "^1.9.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
@@ -28,6 +26,8 @@
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.32.0",
         "@typescript-eslint/parser": "^8.32.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2",
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^9.26.0",
@@ -51,7 +51,9 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2943,6 +2945,7 @@
       "version": "13.15.0",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.0.tgz",
       "integrity": "sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4367,12 +4370,14 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
       "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.11.8",
@@ -10201,6 +10206,7 @@
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.7.tgz",
       "integrity": "sha512-0nYZSNj/QEikyhcM5RZFXGlCB/mr4PVamnT1C2sKBnDDTYndrvbybYjvg+PMqAndQHlLbwQ3socolnL3WWTUFA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lilconfig": {
@@ -14461,6 +14467,7 @@
       "version": "13.15.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
       "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/package.json
+++ b/package.json
@@ -47,9 +47,7 @@
     }
   },
   "dependencies": {
-    "axios": "^1.9.0",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.2"
+    "axios": "^1.9.0"
   },
   "devDependencies": {
     "@nestjs/common": "^11.1.0",
@@ -85,10 +83,14 @@
     "release-it": "^19.0.2",
     "supertest": "^7.1.0",
     "ts-jest": "^29.3.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2"
   }
 }


### PR DESCRIPTION
- Removed class-transformer and class-validator from dependencies in package.json.
- Re-added class-transformer and class-validator to devDependencies in package.json and package-lock.json for better organization.
- Ensured consistency in peerDependencies across both files.