### PR TITLE
refactor: integrate environment validation in ParasutConfig usage

### DIFF
--- a/lib/config/parasut.config.ts
+++ b/lib/config/parasut.config.ts
@@ -44,28 +44,6 @@ export class ParasutConfig {
   @IsNumber()
   @IsOptional()
   timeout?: number;
-
-  constructor(envs: {
-    parasutClientId: string;
-    parasutSecret: string;
-    redirectUri: string;
-    parasutCompanyId: string;
-    parasutEmail: string;
-    parasutPassword: string;
-    parasutEnv: ParasutEnvironment;
-    timeout?: number;
-  }) {
-    validateEnvs(envs);
-
-    this.parasutClientId = envs.parasutClientId;
-    this.parasutSecret = envs.parasutSecret;
-    this.redirectUri = envs.redirectUri;
-    this.parasutCompanyId = envs.parasutCompanyId;
-    this.parasutEmail = envs.parasutEmail;
-    this.parasutPassword = envs.parasutPassword;
-    this.parasutEnv = envs.parasutEnv;
-    this.timeout = envs.timeout;
-  }
 }
 
 export function validateEnvs(envs: Record<string, unknown>) {

--- a/lib/parasut-core.module.ts
+++ b/lib/parasut-core.module.ts
@@ -2,7 +2,7 @@ import { DynamicModule, Logger, Module, Provider } from "@nestjs/common";
 import { CircuitBreaker } from "./common/circuit-breaker";
 import { ParasutLoggerService } from "./common/parasut.logger";
 import { PerformanceService } from "./common/performance-metric";
-import { ParasutConfig } from "./config/parasut.config";
+import { ParasutConfig, validateEnvs } from "./config/parasut.config";
 import {
   ParasutModuleAsyncOptions,
   ParasutModuleOptions,
@@ -60,7 +60,7 @@ export class ParasutCoreModule {
 
     const configProvider: Provider = {
       provide: ParasutConfig,
-      useValue: new ParasutConfig({
+      useValue: validateEnvs({
         parasutEnv: options.credentials.environment,
         parasutClientId: options.credentials.clientId,
         redirectUri: options.credentials.redirectUri,
@@ -160,7 +160,7 @@ export class ParasutCoreModule {
     const configProvider: Provider = {
       provide: ParasutConfig,
       useFactory: (parasutOptions: ParasutModuleOptions) => {
-        return new ParasutConfig({
+        return validateEnvs({
           parasutEnv: parasutOptions.credentials.environment,
           parasutClientId: parasutOptions.credentials.clientId,
           redirectUri: parasutOptions.credentials.redirectUri,

--- a/lib/parasut.provider.ts
+++ b/lib/parasut.provider.ts
@@ -1,6 +1,6 @@
 import { Provider, Type } from "@nestjs/common";
 import { ParasutLoggerService } from "./common/parasut.logger";
-import { ParasutConfig } from "./config/parasut.config";
+import { ParasutConfig, validateEnvs } from "./config/parasut.config";
 import {
   ParasutModuleAsyncOptions,
   ParasutModuleOptions,
@@ -78,7 +78,7 @@ export const createAsyncProviders = (
         inject: [PARASUT_MODULE_OPTIONS],
         provide: ParasutConfig,
         useFactory: (options: ParasutModuleOptions) => {
-          return new ParasutConfig({
+          return validateEnvs({
             parasutEnv: options.credentials.environment,
             parasutClientId: options.credentials.clientId,
             redirectUri: options.credentials.redirectUri,


### PR DESCRIPTION
- Updated ParasutCoreModule and ParasutProvider to utilize validateEnvs for environment configuration, enhancing validation consistency.
- Removed the constructor from ParasutConfig to streamline the configuration process and ensure environment variables are validated directly.