### PR TITLE
refactor: update EArchiveRequestAttributes for optional fields

### DIFF
--- a/lib/modules/formalization/dto/e-archive.attr.ts
+++ b/lib/modules/formalization/dto/e-archive.attr.ts
@@ -34,21 +34,21 @@ export type EArchiveRequestAttributes = {
     sales_excise_duty_code: number;
   }>;
   internet_sale?: {
-    url: string;
-    payment_type:
+    url?: string;
+    payment_type?:
       | "KREDIKARTI/BANKAKARTI"
       | "EFT/HAVALE"
       | "KAPIDAODEME"
       | "ODEMEARACISI";
-    payment_platform: string;
-    payment_date: string;
+    payment_platform?: string;
+    payment_date?: string;
   };
   shipment?: {
-    title: string;
-    vkn: string;
-    name: string;
-    tckn: string;
-    date: string;
+    title?: string;
+    vkn?: string;
+    name?: string;
+    tckn?: string;
+    date?: string;
   };
 };
 


### PR DESCRIPTION
This pull request makes the `internet_sale` and `shipment` fields in the `EArchiveRequestAttributes` type more flexible by making their properties optional. This change will help prevent errors when some fields are not provided and allow for partial data submissions.

Type definition improvements:

* Changed the properties in the `internet_sale` object (`url`, `payment_type`, `payment_platform`, `payment_date`) to be optional, allowing requests that omit these fields.
* Changed the properties in the `shipment` object (`title`, `vkn`, `name`, `tckn`, `date`) to be optional, supporting cases where shipment information may be incomplete or unavailable.