### PR TITLE
refactor: update redirect_uri validation in ParasutAuthDto

### DIFF
--- a/lib/dto/request/login.request.ts
+++ b/lib/dto/request/login.request.ts
@@ -3,7 +3,6 @@ import {
   IsEnum,
   IsNotEmpty,
   IsString,
-  IsUrl,
   ValidateIf,
 } from "class-validator";
 import { GrantType } from "../../parasut.enum";
@@ -38,7 +37,7 @@ export class ParasutAuthDto {
       o.grant_type === GrantType.AUTHORIZATION_CODE ||
       o.grant_type === GrantType.PASSWORD
   )
-  @IsUrl({ require_tld: false })
+  @IsString({ message: "Invalid redirect uri" })
   redirect_uri?: string;
 
   constructor(dto?: ParasutAuthDto) {


### PR DESCRIPTION
This pull request makes a minor update to the validation logic for the `redirect_uri` field in the `ParasutAuthDto` class. The change ensures that the field is validated as a string rather than a URL, and provides a custom error message for invalid input.

Validation update:

* Changed the validator for `redirect_uri` in `ParasutAuthDto` from `@IsUrl` to `@IsString`, including a custom error message for invalid values.
* Removed the unused import of `IsUrl` from `class-validator` in `login.request.ts`.